### PR TITLE
Fix Issue 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 # cookiecutter-brightwaylib
 
-A cookiecutter based project template for Brightway ecosystem packages.
+A [cookiecutter](https://cookiecutter.readthedocs.io/en/stable/index.html) based project template for Brightway ecosystem packages.
 
-# Usage
+# [Usage](https://cookiecutter.readthedocs.io/en/stable/usage.html)
 
-This is a cookiecutter based template to create Brightway ecosystem packages.
-The regular usage instructions from cookiecutter apply:
+1. Create a new environment (pip or conda), activate it, and install `cookiecutter`
+2. Download (i.e. don't install via pip or conda) this repository, either directly or via git
+3. Edit the `cookiecutter.json` file to give your personal info. You should update at least:
 
-1. Install cookiecutter
-2. Invoke cookiecutter passing either this repository as URL or a cloned local directory.
+* "full_name"
+* "email"
+* "github_username"
+
+4. Invoke cookiecutter *in the parent directory of `cookiecutter-brightwaylib`*
 
 ```
 cookiecutter cookiecutter-brightwaylib/

--- a/{{cookiecutter.project_name}}/.github/workflows/python-package-deploy.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/python-package-deploy.yml
@@ -26,8 +26,6 @@ jobs:
       run: >-
         python -m
         build
-        --sdist
-        --wheel
         --outdir dist/
         .
     - name: Publish distribution 📦 to Test PyPI

--- a/{{cookiecutter.project_name}}/MANIFEST.in
+++ b/{{cookiecutter.project_name}}/MANIFEST.in
@@ -1,0 +1,1 @@
+include {{ cookiecutter.package_name }}/VERSION


### PR DESCRIPTION
Fix issue #12 

The template'S  `setup.cfg` uses a non-python/c file to specify the package version: `{{ cookiecutter.package_name }}/VERSION` setuptools without scm will not include it by default. This ends up creating a source distribution without the given file.
We add this `VERSION` file explicitly in a MANIFEST.in at the root of the project directory.