### PR TITLE
Missing quotes in `pyproject.toml` and `__init__.py`

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -34,9 +34,9 @@ dependencies = [
 ]
 
 [project.urls]
-source = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_name}}
-homepage = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_name}}
-tracker = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_name}}/issues
+source = "https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_name}}"
+homepage = "https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_name}}"
+tracker = "https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_name}}/issues"
 
 [project.optional-dependencies]
 # Getting recursive dependencies to work is a pain, this

--- a/{{cookiecutter.project_name}}/{{cookiecutter.package_name}}/__init__.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.package_name}}/__init__.py
@@ -5,4 +5,4 @@ __all__ = (
     # Add functions and variables you want exposed in `{{cookiecutter.package_name}}.` namespace here
 )
 
-__version__ = {{cookiecutter.version}}
+__version__ = "{{cookiecutter.version}}"


### PR DESCRIPTION
The cookiecutter template is missing quotes in `pyproject.toml` for the `[project.urls]` header and `__version__` value in `__init__.py`.

In the generation of a new package I get the errors:

```python
File "tomli/_parser.py", line 649, in parse_value
    raise suffixed_err(src, pos, "Invalid value")
pip._vendor.tomli.TOMLDecodeError: Invalid value (at line 37, column 10)
```

and 

```python
File "__init__.py", line 8
  __version__ = 0.0.1
                    ^^
SyntaxError: invalid syntax
```