### PR TITLE
feat: parametrize the code of conduct contact

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -15,5 +15,6 @@
     "ISC"
   ],
   "copyright_year": 2024,
+  "code_of_conduct_contact": "cmutel@gmail.com",
   "_copy_without_render": [".github/*"]
 }

--- a/{{cookiecutter.project_name}}/CODE_OF_CONDUCT.md
+++ b/{{cookiecutter.project_name}}/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at cmutel@gmail.com. All
+reported by contacting the project team at {{ cookiecutter.code_of_conduct_contact }}. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
When users do not use the cookiecutter template for packages hosted by the brightway-lca/sentier-dev ecosystem, they can now change the code of conduct enforcer contact.

closes #47

(ʘ‿ʘ)╯